### PR TITLE
fix: quantidade do superalimento atualiza quando 0 alimentos

### DIFF
--- a/Server/Models/alimento.model.js
+++ b/Server/Models/alimento.model.js
@@ -50,14 +50,23 @@ Alimento.belongsTo(Superalimento, {
 
 const updateSuperQTD = async (instance) => {
     try {
-        const total_qtd = await Alimento.sum('quantidade', { where: {superalimentoID: instance.superalimentoID} });
-        await Superalimento.update({ quantidade: total_qtd }, { where: { id: instance.superalimentoID } });
+        const [results, metadata] = await sequelize.query(`
+            UPDATE "Superalimentos"
+            SET quantidade = (
+                SELECT COALESCE(SUM(quantidade), 0)
+                FROM "Alimentos"
+                WHERE "superalimentoID" = :superalimentoID
+            )
+            WHERE id = :superalimentoID;
+        `, {
+            replacements: { superalimentoID: instance.superalimentoID }
+        });
 
     } catch (err) {
         console.error('Erro ao atualizar quantidade de Superalimento', err);
     }
+};
 
-}
 
 const updateSuperQTDForBulkCreate = async (instances, transaction) => {
     try {


### PR DESCRIPTION
Quantidade de alimentos no superalimento atualiza corretamente quando o último alimento é deletado.

Eficiência do cálculo da quantidade melhorada em aproximadamente 2.5x (sequelize é horrível, SQL é top)